### PR TITLE
use specific version of mongo for xenial ubuntu

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN \
 # install mongo
  curl -o \
  /tmp/mongo.tgz -L \
-	https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu1404-$MONGO_VERSION.tgz  && \
+	https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu1604-$MONGO_VERSION.tgz  && \
  mkdir -p \
 	/tmp/mongo_app && \
  tar xf \

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ If you need to use a reverse proxy for plexrequest, set `URL_BASE` to `/<name>`.
 
 ## Versions
 
++ **18.09.16:** Use specific mongo version for xenial.
 + **12.09.16:** Rebase to ubuntu xenial, move to linuxserver repository
 + **27.02.16:** Bump to latest release
 + **05.02.16:** Initial Release.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[![linuxserver.io](https://www.linuxserver.io/wp-content/uploads/2015/06/linuxserver_medium.png)](https://linuxserver.io)

<!--- Before submitting a pull request please check the following -->

<!---  That you have made a branch in your fork, we'd rather not merge from your master -->

<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->

<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->

<!---  -->
## Thanks, team linuxserver.io
- Use xenial ubuntu specific version of mongo
- https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu1604-3.2.9.tgz
