### PR TITLE
pin version of meteor as latest has error with allowing root to build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,8 +50,9 @@ RUN \
 	$COPIED_APP_PATH --strip-components=1 && \
  cd $COPIED_APP_PATH && \
  HOME=/tmp \
+ export METEOR_NO_RELEASE_CHECK=true && \
  curl -sL \
-	https://install.meteor.com | \
+	https://install.meteor.com/?release=1.4.1.3 | \
 	sed s/--progress-bar/-sL/g | /bin/sh && \
  HOME=/tmp \
  meteor build \

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,10 +20,10 @@ RUN \
  apt-get install -y \
 	curl && \
  curl -sL \
-	https://deb.nodesource.com/setup_4.x | bash - && \
+	https://deb.nodesource.com/setup_0.10 | bash - && \
  apt-get install -y \
 	--no-install-recommends \
-	nodejs && \
+	nodejs=0.10.48-1nodesource1~xenial1 && \
  npm install -g npm@latest && \
 
 # install mongo

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,10 +20,10 @@ RUN \
  apt-get install -y \
 	curl && \
  curl -sL \
-	https://deb.nodesource.com/setup_0.10 | bash - && \
+	https://deb.nodesource.com/setup_4.x | bash - && \
  apt-get install -y \
 	--no-install-recommends \
-	nodejs=0.10.48-1nodesource1~xenial1 && \
+	nodejs && \
  npm install -g npm@latest && \
 
 # install mongo


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)](https://linuxserver.io)

<!--- Before submitting a pull request please check the following -->

<!---  That you have made a branch in your fork, we'd rather not merge from your master -->

<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->

<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->

<!---  -->
## Thanks, team linuxserver.io
- use a pinned version of meteor as latest has an issue with allowing root to build.
